### PR TITLE
Fix reading unicode completions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,19 +6,12 @@ import { HOLExtensionContext } from './hol_extension_context';
 import { log, error } from './common';
 
 
-function loadUnicodeCompletions(context: vscode.ExtensionContext) {
+function loadUnicodeCompletions(context: vscode.ExtensionContext): { [key: string]: string } {
     let unicodeCompletionsFilepath = context.asAbsolutePath('unicode-completions.json');
-    let completions: { [key: string]: string } = {};
 
     log('Loading unicode completions.');
-    fs.readFile(unicodeCompletionsFilepath, (err, data) => {
-        if (err) {
-            error(`Unable to read unicode completions file: ${err}`);
-            vscode.window.showErrorMessage('Unable to load unicode completions.');
-        }
-
-        completions = JSON.parse(data.toString());
-    });
+    const data = fs.readFileSync(unicodeCompletionsFilepath);
+    const completions: { [key: string]: string } = JSON.parse(data.toString());
 
     return completions;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,9 +10,14 @@ function loadUnicodeCompletions(context: vscode.ExtensionContext): { [key: strin
     let unicodeCompletionsFilepath = context.asAbsolutePath('unicode-completions.json');
 
     log('Loading unicode completions.');
-    const data = fs.readFileSync(unicodeCompletionsFilepath);
-    const completions: { [key: string]: string } = JSON.parse(data.toString());
-
+    let completions: { [key: string]: string } = {};
+    try {
+        const data = fs.readFileSync(unicodeCompletionsFilepath);
+        completions = JSON.parse(data.toString());
+    } catch (err) {
+        error(`Unable to read unicode completions file: ${err}`);
+        vscode.window.showErrorMessage('Unable to load unicode completions.');
+    }
     return completions;
 }
 


### PR DESCRIPTION
Looks like after some reshuffling, unicode completions stopped working. The completions were returned before the json file could be read.