### PR TITLE
feat: Add an optional executed code overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,13 @@
                 "title": "Collapse all cells",
                 "icon": "$(collapse-all)",
                 "category": "HOL"
+            },
+            {
+                "command": "hol4-mode.clearExecutionHistory",
+                "title": "Clear execution history and decorations",
+                "icon": "$(clear-all)",
+                "category": "HOL",
+                "enablement": "config.hol4-mode.executionTracking"
             }
         ],
         "keybindings": [
@@ -309,6 +316,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show raw input/output in console view"
+                },
+                "hol4-mode.executionTracking": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable code execution overlay"
                 },
                 "hol4-mode.holdir": {
                     "type": "string",

--- a/src/executionTracker.ts
+++ b/src/executionTracker.ts
@@ -1,0 +1,244 @@
+import * as vscode from 'vscode';
+
+export enum ActionType {
+    goal = 'goal',
+    selection = 'selection',
+    untilCursor = 'untilcursor',
+    subgoal = 'subgoal',
+    tactic = 'tactic',
+    tacticLine = 'tacticline'
+}
+
+export interface ExecutedAction {
+    id: string;
+    type: ActionType;
+    documentUri: string;
+    range: vscode.Range;
+    text: string;
+}
+
+export interface PendingAction {
+    type: ActionType;
+    editor: vscode.TextEditor;
+    range: vscode.Range;
+    text: string;
+}
+
+/**
+ * Manages tracking and visual decoration of executed code ranges
+ */
+export class ExecutionTracker {
+    private executedActions: ExecutedAction[] = [];
+    private executedDecorationType: vscode.TextEditorDecorationType;
+    private pendingDecorationType: vscode.TextEditorDecorationType;
+    private nextActionId = 1;
+    private currentGoalId: string | null = null;
+    private pendingActions: Map<string, PendingAction> = new Map();
+
+    private isExecutionTrackingEnabled(): boolean {
+        return vscode.workspace.getConfiguration('hol4-mode').get('executionTracking', false);
+    }
+
+    constructor() {
+        this.executedDecorationType = vscode.window.createTextEditorDecorationType({
+            backgroundColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
+            isWholeLine: false,
+            overviewRulerColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
+            overviewRulerLane: vscode.OverviewRulerLane.Right
+        });
+
+        this.pendingDecorationType = vscode.window.createTextEditorDecorationType({
+            backgroundColor: 'rgba(255, 255, 255, 0.1)',
+            border: '1px dashed',
+            borderColor: 'rgba(255, 255, 255, 0.3)',
+            isWholeLine: false,
+            overviewRulerColor: 'rgba(255, 255, 255, 0.2)',
+            overviewRulerLane: vscode.OverviewRulerLane.Right
+        });
+
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (editor) {
+                this.updateDecorations(editor);
+            }
+        });
+
+        vscode.window.onDidChangeVisibleTextEditors(editors => {
+            editors.forEach(editor => {
+                this.updateDecorations(editor);
+            });
+        });
+
+        if (this.isExecutionTrackingEnabled()) {
+            vscode.window.visibleTextEditors.forEach(editor => {
+                this.updateDecorations(editor);
+            });
+        }
+    }
+
+    recordAction(
+        type: ActionType,
+        editor: vscode.TextEditor,
+        range: vscode.Range,
+        text: string,
+    ): string {
+        const action: ExecutedAction = {
+            id: `action-${this.nextActionId++}`,
+            type,
+            documentUri: editor.document.uri.toString(),
+            range,
+            text,
+        };
+
+        this.executedActions.push(action);
+        this.updateDecorations(editor);
+        
+        if (type === ActionType.goal) {
+            this.currentGoalId = action.id;
+        }
+        
+        return action.id;
+    }
+
+    recordPendingAction(
+        type: ActionType,
+        editor: vscode.TextEditor,
+        range: vscode.Range,
+        text: string,
+    ): string {
+        const actionId = `action-${this.nextActionId++}`;
+        this.pendingActions.set(actionId, {
+            type,
+            editor,
+            range,
+            text,
+        });
+        
+        this.updateDecorations(editor);
+        
+        return actionId;
+    }
+
+    confirmAction(actionId: string): void {
+        const pending = this.pendingActions.get(actionId);
+        if (pending) {
+            this.pendingActions.delete(actionId);
+            this.recordAction(
+                pending.type,
+                pending.editor,
+                pending.range,
+                pending.text,
+            );
+            this.updateDecorations(pending.editor);
+        }
+    }
+
+    cancelAction(actionId: string): void {
+        const pending = this.pendingActions.get(actionId);
+        if (pending) {
+            this.pendingActions.delete(actionId);
+            this.updateDecorations(pending.editor);
+        }
+    }
+
+    getActionsForDocument(documentUri: string): ExecutedAction[] {
+        return this.executedActions.filter(action => action.documentUri === documentUri);
+    }
+
+    stepBack(count: number = 1): ExecutedAction[] {
+        const removedActions: ExecutedAction[] = [];
+        for (let i = 0; i < count && this.executedActions.length > 0 && this.currentGoalId && this.executedActions[this.executedActions.length - 1].id !== this.currentGoalId; i++) {
+            const removed = this.executedActions.pop();
+            if (removed) {
+                removedActions.push(removed);
+            }
+        }
+
+        vscode.window.visibleTextEditors.forEach(editor => {
+            this.updateDecorations(editor);
+        });
+
+        return removedActions;
+    }
+
+    clearAll(): ExecutedAction[] {
+        const clearedActions = [...this.executedActions];
+        this.executedActions = [];
+        this.currentGoalId = null;
+
+        vscode.window.visibleTextEditors.forEach(editor => {
+            this.updateDecorations(editor);
+        });
+
+        return clearedActions;
+    }
+
+    clearCurrentGoal(): ExecutedAction[] {
+        if (!this.currentGoalId) {
+            return [];
+        }
+
+        const goalIndex = this.executedActions.findIndex(action => action.id === this.currentGoalId);
+        if (goalIndex === -1) {
+            return [];
+        }
+
+        const removedActions = this.executedActions.splice(goalIndex + 1);
+
+        vscode.window.visibleTextEditors.forEach(editor => {
+            this.updateDecorations(editor);
+        });
+
+        return removedActions;
+    }
+
+    dropCurrentGoal(): ExecutedAction[] {
+        if (!this.currentGoalId) {
+            return [];
+        }
+
+        const goalIndex = this.executedActions.findIndex(action => action.id === this.currentGoalId);
+        if (goalIndex === -1) {
+            return [];
+        }
+
+        const removedActions = this.executedActions.splice(goalIndex);
+        this.currentGoalId = null;
+
+        vscode.window.visibleTextEditors.forEach(editor => {
+            this.updateDecorations(editor);
+        });
+
+        return removedActions;
+    }
+
+    private updateDecorations(editor: vscode.TextEditor): void {
+        if (!this.isExecutionTrackingEnabled()) {
+            editor.setDecorations(this.executedDecorationType, []);
+            editor.setDecorations(this.pendingDecorationType, []);
+            return;
+        }
+
+        const documentActions = this.getActionsForDocument(editor.document.uri.toString());
+        const executedDecorations: vscode.DecorationOptions[] = documentActions.map(action => ({
+            range: action.range,
+        }));
+
+        // Get pending actions for this document
+        const pendingDecorations: vscode.DecorationOptions[] = [];
+        for (const [actionId, pendingAction] of this.pendingActions) {
+            if (pendingAction.editor.document.uri.toString() === editor.document.uri.toString()) {
+                pendingDecorations.push({
+                    range: pendingAction.range,
+                });
+            }
+        }
+
+        editor.setDecorations(this.executedDecorationType, executedDecorations);
+        editor.setDecorations(this.pendingDecorationType, pendingDecorations);
+    }
+
+    dispose(): void {
+        this.executedDecorationType.dispose();
+        this.pendingDecorationType.dispose();
+    }
+}

--- a/src/executionTracker.ts
+++ b/src/executionTracker.ts
@@ -44,7 +44,8 @@ export class ExecutionTracker {
             backgroundColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
             isWholeLine: false,
             overviewRulerColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
-            overviewRulerLane: vscode.OverviewRulerLane.Right
+            overviewRulerLane: vscode.OverviewRulerLane.Right,
+            rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed
         });
 
         this.pendingDecorationType = vscode.window.createTextEditorDecorationType({
@@ -53,7 +54,8 @@ export class ExecutionTracker {
             borderColor: 'rgba(255, 255, 255, 0.3)',
             isWholeLine: false,
             overviewRulerColor: 'rgba(255, 255, 255, 0.2)',
-            overviewRulerLane: vscode.OverviewRulerLane.Right
+            overviewRulerLane: vscode.OverviewRulerLane.Right,
+            rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed
         });
 
         vscode.window.onDidChangeActiveTextEditor(editor => {
@@ -219,22 +221,15 @@ export class ExecutionTracker {
         }
 
         const documentActions = this.getActionsForDocument(editor.document.uri.toString());
-        const executedDecorations: vscode.DecorationOptions[] = documentActions.map(action => ({
-            range: action.range,
-        }));
+        const executedRanges = documentActions.map(action => action.range);
 
         // Get pending actions for this document
-        const pendingDecorations: vscode.DecorationOptions[] = [];
-        for (const [actionId, pendingAction] of this.pendingActions) {
-            if (pendingAction.editor.document.uri.toString() === editor.document.uri.toString()) {
-                pendingDecorations.push({
-                    range: pendingAction.range,
-                });
-            }
-        }
+        const pendingRanges = Array.from(this.pendingActions.values())
+            .filter(pendingAction => pendingAction.editor.document.uri.toString() === editor.document.uri.toString())
+            .map(pendingAction => pendingAction.range);
 
-        editor.setDecorations(this.executedDecorationType, executedDecorations);
-        editor.setDecorations(this.pendingDecorationType, pendingDecorations);
+        editor.setDecorations(this.executedDecorationType, executedRanges);
+        editor.setDecorations(this.pendingDecorationType, pendingRanges);
     }
 
     dispose(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ function initialize(context: vscode.ExtensionContext): HOLExtensionContext | und
         // Get the path to the current workspace root. This class is constructed
         // by the extension, which is activated by opening a HOL4 document. By
         // this time there should be a workspace.
-        if (vscode.workspace.workspaceFolders.length == 1) {
+        if (vscode.workspace.workspaceFolders.length === 1) {
             const workspacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
             holIDE = new HOLIDE(context, holPath, workspacePath);
         } else {
@@ -42,8 +42,8 @@ function initialize(context: vscode.ExtensionContext): HOLExtensionContext | und
     // Cleanup orphaned tabs from previous session
     for (const group of vscode.window.tabGroups.all) {
         for (const tab of group.tabs) {
-            if (tab.label == 'HOL4 Session' &&
-                !vscode.workspace.notebookDocuments.some(doc => doc.uri == (tab.input as { uri?: vscode.Uri }).uri)) {
+            if (tab.label === 'HOL4 Session' &&
+                !vscode.workspace.notebookDocuments.some(doc => doc.uri === (tab.input as { uri?: vscode.Uri }).uri)) {
                 vscode.window.tabGroups.close(tab);
             }
         }
@@ -159,6 +159,11 @@ export function activate(context: vscode.ExtensionContext) {
             await holExtensionContext?.notebook?.clearAll();
         }),
 
+        // Clear execution history and decorations
+        vscode.commands.registerCommand('hol4-mode.clearExecutionHistory', () => {
+            holExtensionContext?.clearExecutionHistory();
+        }),
+
         vscode.commands.registerCommand('hol4-mode.restart', () => {
             (async () => {
                 await holExtensionContext?.notebook?.stop();
@@ -182,7 +187,7 @@ export function activate(context: vscode.ExtensionContext) {
                 if (vscode.languages.match(hol4selector, doc)) {
                     (async () => {
                         const server = await holExtensionContext?.holIDE?.startServer(doc);
-                        if (server) await holExtensionContext?.holIDE?.compileDocument(server, doc);
+                        if (server) { await holExtensionContext?.holIDE?.compileDocument(server, doc); }
                     })();
                     holExtensionContext?.holIDE?.updateImports(doc);
                 }
@@ -193,7 +198,7 @@ export function activate(context: vscode.ExtensionContext) {
             if (vscode.languages.match(hol4selector, doc)) {
                 (async () => {
                     const server = await holExtensionContext?.holIDE?.startServer(doc);
-                    if (server) await holExtensionContext?.holIDE?.compileDocument(server, doc);
+                    if (server) { await holExtensionContext?.holIDE?.compileDocument(server, doc); }
                 })();
                 holExtensionContext?.holIDE?.indexDocument(doc);
             }
@@ -241,5 +246,5 @@ export function activate(context: vscode.ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export function deactivate() {
-    holExtensionContext?.stopSession()
+    holExtensionContext?.stopSession();
 }

--- a/src/extensionContext.ts
+++ b/src/extensionContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { log, error, EXTENSION_ID, KERNEL_ID } from './common';
 import { HolNotebook } from './notebook';
 import { HOLIDE, entryToCompletionItem, entryToSymbol, isAccessibleEntry } from './holIDE';
+import { ExecutionTracker, ActionType } from './executionTracker';
 
 /**
  * Generate a HOL lexer location pragma from a vscode Position value.
@@ -15,11 +16,11 @@ function positionToLocationPragma(pos: vscode.Position): string {
  * Get the editors current selection if any, or the contents of the editor's
  * current line otherwise.
  */
-function getSelection(editor: vscode.TextEditor): string {
-    const document = editor.document;
+function getSelection(editor: vscode.TextEditor): vscode.Selection {
     const selection = editor.selection;
-    return selection.isEmpty ? document.lineAt(selection.active.line).text
-        : document.getText(selection);
+    return selection.isEmpty 
+            ? new vscode.Selection(selection.active.line, 0, selection.active.line, editor.document.lineAt(selection.active.line).text.length)
+            : selection;
 }
 
 /**
@@ -149,13 +150,13 @@ function selectBetween(editor: vscode.TextEditor, init: RegExp, stop: RegExp): v
  *
  * @note this function embeds a location pragma in the string it returns.
  */
-function extractGoal(editor: vscode.TextEditor): [string, string] | undefined {
+function extractGoal(editor: vscode.TextEditor): [string, vscode.Selection] | undefined {
     const selection = editor.selection;
     const document = editor.document;
 
     if (!selection.isEmpty) {
         const locPragma = positionToLocationPragma(selection.anchor);
-        return [locPragma, document.getText(selection)];
+        return [locPragma, selection];
     }
 
     const spanBegin = /^(Theorem|Triviality)\s+[^\[\:]+(\[[^\]]*\])?\s*\:/;
@@ -168,7 +169,7 @@ function extractGoal(editor: vscode.TextEditor): [string, string] | undefined {
         (sel = selectBetween(editor, /``/, /``/)) ||
         (sel = selectBetween(editor, /`/, /`/))) {
         const locPragma = positionToLocationPragma(sel.anchor);
-        return [locPragma, document.getText(sel)];
+        return [locPragma, sel];
     }
 
     return;
@@ -178,20 +179,20 @@ function extractGoal(editor: vscode.TextEditor): [string, string] | undefined {
  * Identical to {@link extractGoal} but only accepts term quotations.
  * @todo Merge with extractGoal.
  */
-function extractSubgoal(editor: vscode.TextEditor): [string, string] | undefined {
+function extractSubgoal(editor: vscode.TextEditor): [string, vscode.Selection] | undefined {
     const selection = editor.selection;
     const document = editor.document;
 
     if (!selection.isEmpty) {
         const locPragma = positionToLocationPragma(selection.anchor);
-        return [locPragma, document.getText(selection)];
+        return [locPragma, selection];
     }
 
     let sel;
     if ((sel = selectBetween(editor, /‘/, /’/)) ||
         (sel = selectBetween(editor, /`/, /`/))) {
         const locPragma = positionToLocationPragma(sel.anchor);
-        return [locPragma, document.getText(sel)];
+        return [locPragma, sel];
     }
 
     return;
@@ -204,6 +205,9 @@ export class HOLExtensionContext implements
     /** Currently active notebook editor (if any). */
     public notebook?: HolNotebook;
 
+    /** Execution tracker for managing code decorations and history. */
+    public executionTracker: ExecutionTracker;
+
     constructor(
         private context: vscode.ExtensionContext,
 
@@ -212,7 +216,32 @@ export class HOLExtensionContext implements
 
         /** Current IDE class instance. */
         public holIDE?: HOLIDE
-    ) { }
+    ) {
+        this.executionTracker = new ExecutionTracker();
+    }
+
+    private pendingActionCell: Map<string, string> = new Map(); // cellUri -> actionId
+    
+    private setupKernelListeners() {
+        if (this.notebook?.kernel) {
+            this.notebook.kernel.onExecComplete(({ cell, success }) => {
+                this.handleExecutionComplete(cell, success);
+            });
+        }
+    }
+
+    private handleExecutionComplete(cell: vscode.NotebookCell, success: boolean) {
+        const cellKey = `${cell.notebook.uri.toString()}#${cell.index}`;
+        const actionId = this.pendingActionCell.get(cellKey);
+        if (actionId) {
+            this.pendingActionCell.delete(cellKey);
+            if (success) {
+                this.executionTracker.confirmAction(actionId);
+            } else {
+                this.executionTracker.cancelAction(actionId);
+            }
+        }
+    }
 
     /** Returns whether the current session is active. If it is not active, then
      * an error message is printed.
@@ -252,9 +281,9 @@ export class HOLExtensionContext implements
                 return e.notebook.metadata.hol || (
                     // Heuristic identification of orphaned HOL windows
                     e.notebook.isUntitled &&
-                    e.notebook.cellCount == 0 &&
-                    e.notebook.notebookType == 'interactive'
-                )
+                    e.notebook.cellCount === 0 &&
+                    e.notebook.notebookType === 'interactive'
+                );
             });
             if (!notebookEditor) {
                 const result = await vscode.commands.executeCommand<{ notebookEditor?: vscode.NotebookEditor }>(
@@ -296,6 +325,9 @@ export class HOLExtensionContext implements
 
         this.notebook.show();
         await this.notebook.start();
+
+        this.setupKernelListeners();
+
         log('Started session');
     }
 
@@ -307,14 +339,18 @@ export class HOLExtensionContext implements
             return;
         }
 
+        this.executionTracker.clearAll();
+
         log('Stopped session');
         this.notebook!.close();
     }
 
     /**
-     * Stop the HOL terminal session.
+     * Restart the HOL terminal session.
      */
     restartSession(editor: vscode.TextEditor) {
+        this.executionTracker.clearAll();
+
         log('Restarted session');
         this.notebook?.stop();
         this.startSession(editor);
@@ -342,7 +378,13 @@ export class HOLExtensionContext implements
             await this.startSession(editor);
         }
 
-        const text = getSelection(editor);
+        const selection = getSelection(editor);
+        const text = editor.document.getText(selection);
+
+        const actionId = this.executionTracker.recordPendingAction(ActionType.selection, editor, selection, text);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
 
         await this.notebook!.send(text, true, true);
     }
@@ -359,9 +401,13 @@ export class HOLExtensionContext implements
         }
 
         const currentLine = editor.selection.active.line;
-
         const selection = new vscode.Selection(0, 0, currentLine, 0);
         const text = editor.document.getText(selection);
+        
+        const actionId = this.executionTracker.recordPendingAction(ActionType.untilCursor, editor, selection, text);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
 
         await this.notebook!.send(text, true, true);
     }
@@ -375,16 +421,24 @@ export class HOLExtensionContext implements
             await this.startSession(editor);
         }
 
-        let goal = extractGoal(editor);
-        if (!goal) {
+        const goalData = extractGoal(editor);
+        if (!goalData) {
             vscode.window.showErrorMessage('Unable to select a goal term');
             error('Unable to select goal term');
             return;
         }
-        let [locPragma, text] = goal;
+        let [locPragma, goalSelection] = goalData;
+        const text = editor.document.getText(goalSelection);
+        
         const faketext = `proofManagerLib.g(\`${text}\`)`;
         const realtext = `proofManagerLib.g(\`${locPragma}${text}\`)`;
-        const full = `let val x = ${realtext}; val _ = proofManagerLib.set_backup 100 in x end`
+        const full = `let val x = ${realtext}; val _ = proofManagerLib.set_backup 100 in x end`;
+        
+        const actionId = this.executionTracker.recordPendingAction(ActionType.goal, editor, goalSelection, text);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
+
         await this.notebook!.send(faketext, false, true, full);
     }
 
@@ -396,15 +450,23 @@ export class HOLExtensionContext implements
             return;
         }
 
-        let sg = extractSubgoal(editor);
-        if (!sg) {
+        let subGoalData = extractSubgoal(editor);
+        if (!subGoalData) {
             vscode.window.showErrorMessage('Unable to select a subgoal term');
             error('Unable to select subgoal term');
             return;
         }
-        let [locPragma, text] = sg;
+        const [locPragma, subGoalSelection] = subGoalData;
+        const text = editor.document.getText(subGoalSelection);
+
         const faketext = `proofManagerLib.e(sg\`${text}\`)`;
         const realtext = `proofManagerLib.e(sg\`${locPragma}${text}\`)`;
+        
+        const actionId = this.executionTracker.recordPendingAction(ActionType.subgoal, editor, subGoalSelection, text);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
+        
         await this.notebook!.send(faketext, false, true, realtext);
     }
 
@@ -416,10 +478,16 @@ export class HOLExtensionContext implements
             return;
         }
 
-        let tacticText = getSelection(editor);
-        tacticText = processTactics(tacticText);
+        const tacticSelection = getSelection(editor);
+        const tacticText0 = editor.document.getText(tacticSelection);
+        const tacticText = processTactics(tacticText0);
         const text = `proofManagerLib.e(${tacticText})`;
         const full = addLocationPragma(text, editor.selection.start);
+
+        const actionId = this.executionTracker.recordPendingAction(ActionType.tactic, editor, tacticSelection, tacticText);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
 
         await this.notebook!.send(text, false, true, full);
     }
@@ -433,10 +501,17 @@ export class HOLExtensionContext implements
             return;
         }
 
-        let tacticText = editor.document.lineAt(editor.selection.active.line).text;
-        tacticText = processTactics(tacticText);
+        const currentLine = editor.selection.active.line;
+        const tacticText0 = editor.document.lineAt(currentLine).text;
+        const tacticText = processTactics(tacticText0);
         const text = `proofManagerLib.e(${tacticText})`;
         const full = addLocationPragma(text, editor.selection.start);
+
+        const tacticSelection = new vscode.Range(currentLine, 0, currentLine, editor.document.lineAt(currentLine).text.length);
+        const actionId = this.executionTracker.recordPendingAction(ActionType.tacticLine, editor, tacticSelection, tacticText);
+        const cellIndex = this.notebook!.notebookEditor.notebook.cellCount;
+        const cellKey = `${this.notebook!.notebookEditor.notebook.uri.toString()}#${cellIndex}`;
+        this.pendingActionCell.set(cellKey, actionId);
 
         await this.notebook!.send(text, false, true, full);
     }
@@ -472,6 +547,8 @@ export class HOLExtensionContext implements
             return;
         }
 
+        this.executionTracker.stepBack(1);
+
         await this.notebook!.send('proofManagerLib.backup ()', false, true);
     }
 
@@ -483,6 +560,8 @@ export class HOLExtensionContext implements
             return;
         }
 
+        this.executionTracker.clearCurrentGoal();
+
         await this.notebook!.send('proofManagerLib.restart ()', false, true);
     }
 
@@ -493,6 +572,8 @@ export class HOLExtensionContext implements
         if (!this.isActive()) {
             return;
         }
+
+        this.executionTracker.dropCurrentGoal();
 
         await this.notebook!.send('proofManagerLib.drop ()', false, true);
     }
@@ -516,6 +597,26 @@ export class HOLExtensionContext implements
             return;
         }
         await this.notebook!.send('Globals.show_assums := not (!Globals.show_assums)', false, true);
+    }
+
+    /**
+     * Clear all execution decorations and history.
+     */
+    clearExecutionHistory() {
+        this.executionTracker.clearAll();
+        vscode.window.showInformationMessage('Execution history cleared');
+    }
+
+    /**
+     * Remove the last executed action (useful for failed tactics).
+     */
+    removeLastAction() {
+        const removed = this.executionTracker.stepBack(1);
+        if (removed.length > 0) {
+            vscode.window.showInformationMessage(`Removed last action: ${removed[0].type}`);
+        } else {
+            vscode.window.showInformationMessage('No actions to remove');
+        }
     }
 
     /**
@@ -546,7 +647,9 @@ export class HOLExtensionContext implements
             markdownString.appendCodeblock(entry.statement);
             results.push(markdownString);
         }
-        if (results) return new vscode.Hover(results, range ?? wordRange);
+        if (results) {
+            return new vscode.Hover(results, range ?? wordRange);
+        }
     }
 
     /**
@@ -564,7 +667,7 @@ export class HOLExtensionContext implements
             entry.name === word &&
             isAccessibleEntry(entry, this.holIDE!.imports[document.uri.toString()], document));
         const defns: vscode.DefinitionLink[] = (await promise?.catch()) ?? [];
-        if (defns.length == 0 && entry) {
+        if (defns.length === 0 && entry) {
             const position = new vscode.Position(entry.line - 1, 0);
             defns.push({
                 targetUri: vscode.Uri.file(entry.file),

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -9,6 +9,11 @@ class Execution {
     private success: boolean = true;
     private writeAnyway: NodeJS.Timeout | undefined;
     constructor(public exec: vscode.NotebookCellExecution) { }
+    
+    get isSuccess(): boolean {
+        return this.success;
+    }
+
     appendOutput(str: string, err?: boolean) {
         const pos = str.lastIndexOf('\n');
         if (pos >= 0) {
@@ -27,7 +32,7 @@ class Execution {
                 }
             }
         } else {
-            if (err) this.markFail();
+            if (err) { this.markFail(); }
             this.buffer += str;
         }
     }
@@ -48,13 +53,13 @@ class Execution {
         this.success = false;
     }
     end(success?: boolean) {
-        if (this.buffer) this.output();
+        if (this.buffer) { this.output(); }
         clearTimeout(this.writeAnyway);
-        this.exec.end(success ?? this.success, Date.now())
+        this.exec.end(success ?? this.success, Date.now());
     }
 }
 
-export type OverflowEvent = { s: string, err: boolean }
+export type OverflowEvent = { s: string, err: boolean };
 export class HolKernel {
     /**
      * The connection to the HOL process itself. May be undefined if the process has not started yet
@@ -75,11 +80,17 @@ export class HolKernel {
      */
     private currentExecution?: Execution;
 
+    /** The current cell being executed, if any. */
+    private currentCell?: vscode.NotebookCell;
+
     /** Fires when a queued cell is about to be executed. */
     private execListener = new vscode.EventEmitter<vscode.NotebookCell>();
 
     /** Fires when HOL says something outside the expected request/response flow. */
     private overflowListener = new vscode.EventEmitter<OverflowEvent>();
+
+    /** Fires when an execution completes with success/failure status. */
+    private execCompleteListener = new vscode.EventEmitter<{ cell: vscode.NotebookCell, success: boolean }>();
 
     private interceptResult: { data: string, finish: (data: string) => void } | undefined = undefined;
 
@@ -123,6 +134,7 @@ export class HolKernel {
 
         this.sync();
         this.currentExecution = new Execution(this.controller.createNotebookCellExecution(cell));
+        this.currentCell = cell;
         this.execListener.fire(cell);
 
         if (this.child) {
@@ -150,15 +162,25 @@ export class HolKernel {
         if (this.interceptResult) {
             this.interceptResult.finish(this.interceptResult.data);
         } else if (this.currentExecution) {
+            const success = this.currentExecution.isSuccess;
             this.currentExecution.end();
+            
+            if (this.currentCell) {
+                this.execCompleteListener.fire({ cell: this.currentCell, success });
+                this.currentCell = undefined;
+            }
+            
             this.currentExecution = undefined;
             const cell = this.executionQueue.shift();
-            if (cell) this.runCell(cell);
+            if (cell) {
+                this.runCell(cell);
+            }
         }
     }
 
     onOverflow = this.overflowListener.event;
     onWillExec = this.execListener.event;
+    onExecComplete = this.execCompleteListener.event;
 
     start(): Promise<void> {
         this.child = child_process.spawn(path.join(this.holPath, 'bin', 'hol'), ['--zero'], {
@@ -170,23 +192,23 @@ export class HolKernel {
         // log(`starting kernel ${this.child.pid}`);
         this.executionOrder = 0;
         const pid = this.child.pid;
-        const onKilled = () => { if (pid === this.child?.pid) this.onKilled() };
+        const onKilled = () => { if (pid === this.child?.pid) { this.onKilled(); } };
         this.child.addListener('disconnect', onKilled);
         this.child.addListener('close', onKilled);
         this.child.addListener('exit', onKilled);
         return new Promise((resolve, reject) => {
             const buffer: string[] = [];
             const listenerStderr = (data: Buffer) => {
-                if (!data.length) return;
+                if (!data.length) { return; }
                 buffer.push(data.toString());
                 // log(`start recv err ${data.toString()}`);
                 const s = buffer.join('');
                 this.overflowListener.fire({ s, err: true });
                 buffer.length = 0;
-                reject(s)
+                reject(s);
             };
             const listenerStdout = (data: Buffer) => {
-                if (!data.length) return;
+                if (!data.length) { return; }
                 if (data.readUint8(data.length - 1) === 0) {
                     buffer.push(data.toString(undefined, undefined, data.length - 1));
                     // log(`start recv ok "${data.toString(undefined, undefined, data.length - 1)}"`);
@@ -201,10 +223,10 @@ export class HolKernel {
                     // log(`start recv ok "${data.toString(undefined, undefined, data.length - 1)}"`);
                     buffer.push(data.toString());
                 }
-            }
+            };
             this.child?.stdout?.on('data', listenerStdout);
             this.child?.stderr?.on('data', listenerStderr);
-        })
+        });
     }
 
     private appendOutput(str: string, err?: boolean) {
@@ -218,9 +240,9 @@ export class HolKernel {
     }
 
     private finishOpen(result: string) {
-        if (result) this.overflowListener.fire({ s: result, err: result.includes('error:') });
+        if (result) { this.overflowListener.fire({ s: result, err: result.includes('error:') }); }
         this.child?.stdout?.on('data', (data: Buffer) => {
-            if (!data.length) return;
+            if (!data.length) { return; }
             if (data.readUint8(data.length - 1) === 0) {
                 this.appendOutput(data.toString(undefined, undefined, data.length - 1));
                 // log(`recv ok "${data.toString(undefined, undefined, data.length - 1)}"`);
@@ -231,7 +253,7 @@ export class HolKernel {
             }
         });
         this.child?.stderr?.on('data', (data: Buffer) => {
-            if (!data.length) return;
+            if (!data.length) { return; }
             this.appendOutput(data.toString(), true);
         });
     }
@@ -253,6 +275,13 @@ export class HolKernel {
         if (this.currentExecution) {
             this.currentExecution.markFail();
             this.currentExecution.end();
+            
+            // Emit execution complete event for cancelled execution
+            if (this.currentCell) {
+                this.execCompleteListener.fire({ cell: this.currentCell, success: false });
+                this.currentCell = undefined;
+            }
+            
             this.currentExecution = undefined;
         }
         this.executionQueue = [];
@@ -273,7 +302,7 @@ export class HolKernel {
     }
 
     sync() {
-        if (this.child && (this.child.killed || !this.child.pid || this.child?.exitCode != null)) {
+        if (this.child && (this.child.killed || !this.child.pid || this.child?.exitCode !== null)) {
             // log(`mystery death of kernel ${this.child.pid}`);
             this.onKilled();
         }

--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -35,6 +35,11 @@ export class HolNotebook {
 
     private overflowPromise: Promise<void>;
 
+    /** Get the notebook editor */
+    get notebookEditor(): vscode.NotebookEditor {
+        return this.editor;
+    }
+
     constructor(
         context: vscode.ExtensionContext,
         private readonly cwd: string,


### PR DESCRIPTION
### Description and Motivation

This PR adds an overlay that appears over executed (and pending) HOL4 code in the current working editor. The feature is hidden by an option and is bu default set to `off`.

This solves one of my main problems when reading HOL4 code:
1. I start a goal
2. I execute some tactics
3. I jump around the editor, to inspect some definitions or just look at some code in a different editor or ...
4. I come back to the HOL4 editor and I cannot figure out what was the state of my proof.

### Demo:

[Kooha-2025-10-03-13-23-41.webm](https://github.com/user-attachments/assets/acf6386a-9501-4330-8481-19e70c47a120)

### Discussion

It is not clear to me what should be the expected result after removing an "executed" piece of code. Should we go back in the proof before that line was executed? AFAIK this can only be done in a "goal" state.

Should there be a better visual indication of the order of executed selections? This could either be done with a gradient or minimally, an indication of the last executed code selection. This might be useful for people that don't necessarily follow a linear order, when developing a proof.

Keeping the list of executed actions opens a possibility of adding a "Send since last selection" command. Would that be useful? (I think that it makes sense for tactics)
