### PR TITLE
add LSP client with HOL Goals side pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,37 @@ Expects a HOL4 installation to exist, and the environment variable `$HOLDIR` to 
 installation. The HOL4 homepage can be found [here](https://hol-theorem-prover.org) and its GitHub
 repository [here](https://github.com/HOL-Theorem-Prover/HOL).
 
+## HOL4 LSP integration
+
+When `hol4-mode.lsp.enabled` is `true` (the default), the extension
+starts a HOL4 [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
+client that speaks to `bin/hol lsp`.  This delivers:
+
+- **Compile-driven diagnostics** in the Problems panel and inline
+  squiggles as you edit.
+- **LSP-provided hover** with type information from the running HOL
+  session (in addition to the existing symbol-index hover, which
+  keeps working).
+- **HOL Goals side pane** — press `Ctrl+H Ctrl+G` (or `Cmd+H Cmd+G`
+  on macOS) to open a pane that follows the cursor and shows the
+  proof state at each tactic step inside a `Proof … QED` block.
+
+Requirements: a HOL4 build recent enough that `bin/hol lsp` is a
+valid subcommand.  See [`tools-poly/lsp/README.md`](https://github.com/HOL-Theorem-Prover/HOL/blob/develop/tools-poly/lsp/README.md)
+in the HOL4 repository for the server contract.
+
+Related settings:
+
+- `hol4-mode.lsp.enabled` (default: `true`) — toggle the client
+  entirely.  With `false` the extension behaves as it did before
+  the LSP integration.
+- `hol4-mode.lsp.executable` (default: empty) — override the path
+  to `bin/hol`.  Falls back to `hol4-mode.holdir/bin/hol`, then
+  `$HOLDIR/bin/hol`.
+
+Palette commands: `HOL: Toggle HOL Goals pane`, `HOL: Restart LSP
+server`, `HOL: Show LSP output channel`.
+
 ## Extension Settings
 
 It is possible to toggle the indexing of theorems and definitions in the workspace from the settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "hol4-mode",
             "version": "0.0.20",
             "dependencies": {
-                "vscode-languageclient": "^9.0.0"
+                "vscode-languageclient": "^9.0.1"
             },
             "devDependencies": {
                 "@types/mocha": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,21 @@
                 "title": "Collapse all cells",
                 "icon": "$(collapse-all)",
                 "category": "HOL"
+            },
+            {
+                "command": "hol4-mode.lsp.toggleGoalsPane",
+                "title": "Toggle HOL Goals pane",
+                "category": "HOL"
+            },
+            {
+                "command": "hol4-mode.lsp.restart",
+                "title": "Restart LSP server",
+                "category": "HOL"
+            },
+            {
+                "command": "hol4-mode.lsp.showOutput",
+                "title": "Show LSP output channel",
+                "category": "HOL"
             }
         ],
         "keybindings": [
@@ -271,6 +286,12 @@
                 "key": "ctrl+h ctrl+a",
                 "mac": "cmd+h cmd+a",
                 "when": "editorLangId == hol4"
+            },
+            {
+                "command": "hol4-mode.lsp.toggleGoalsPane",
+                "key": "ctrl+h ctrl+g",
+                "mac": "cmd+h cmd+g",
+                "when": "editorLangId == hol4"
             }
         ],
         "menus": {
@@ -313,6 +334,16 @@
                 "hol4-mode.holdir": {
                     "type": "string",
                     "description": "Set HOL installation directory"
+                },
+                "hol4-mode.lsp.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable the HOL4 LSP client (spawns `bin/hol lsp`). Diagnostics, hover, and the HOL Goals pane require this."
+                },
+                "hol4-mode.lsp.executable": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Optional path to `bin/hol` for the LSP server. Empty falls back to `hol4-mode.holdir/bin/hol`, then `$HOLDIR/bin/hol`."
                 }
             }
         },
@@ -332,6 +363,9 @@
         "pretest": "npm run compile && npm run lint",
         "lint": "eslint src --ext ts",
         "test": "node ./out/test/runTest.js"
+    },
+    "dependencies": {
+        "vscode-languageclient": "^9.0.1"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,8 @@ import { HOLIDE } from './holIDE';
 import { HOLExtensionContext } from './extensionContext';
 import { log, error, holdir, hol4selector } from './common';
 import { AbbreviationFeature } from './abbreviations';
+import { LspClient } from './lspClient';
+import { GoalsView } from './goalsView';
 
 
 /**
@@ -52,11 +54,23 @@ function initialize(context: vscode.ExtensionContext): HOLExtensionContext | und
 }
 
 let holExtensionContext: HOLExtensionContext | undefined;
+let lspClient: LspClient | undefined;
+let goalsView: GoalsView | undefined;
 export function activate(context: vscode.ExtensionContext) {
     holExtensionContext = initialize(context);
     if (!holExtensionContext) {
         error("Unable to initialize extension.");
         return;
+    }
+
+    const lspEnabled = vscode.workspace.getConfiguration('hol4-mode')
+        .get<boolean>('lsp.enabled', true);
+    if (lspEnabled) {
+        lspClient = new LspClient(holExtensionContext.holPath);
+        lspClient.start();
+        context.subscriptions.push(lspClient);
+        goalsView = new GoalsView(lspClient);
+        context.subscriptions.push(goalsView);
     }
 
     let commands = [
@@ -205,6 +219,18 @@ export function activate(context: vscode.ExtensionContext) {
 
         vscode.commands.registerCommand('hol4-mode.refreshIndex', () => {
             holExtensionContext?.holIDE?.refreshIndex();
+        }),
+
+        vscode.commands.registerCommand('hol4-mode.lsp.toggleGoalsPane', () => {
+            goalsView?.toggle();
+        }),
+
+        vscode.commands.registerCommand('hol4-mode.lsp.restart', () => {
+            lspClient?.restart();
+        }),
+
+        vscode.commands.registerCommand('hol4-mode.lsp.showOutput', () => {
+            lspClient?.showOutput();
         }),
 
         vscode.languages.registerHoverProvider(

--- a/src/goalsView.ts
+++ b/src/goalsView.ts
@@ -1,0 +1,238 @@
+import * as vscode from 'vscode';
+import { KERNEL_ID } from './common';
+import { escapeHtml } from './server';
+import {
+    GoalStateParams,
+    GoalStateResponse,
+    LspClient,
+} from './lspClient';
+
+const DEBOUNCE_MS = 150;
+
+/** Side-pane webview rendering `$/hol/goalState' for the cursor
+ * position; refreshed on debounced selection/editor changes. */
+export class GoalsView implements vscode.Disposable {
+    private panel: vscode.WebviewPanel | undefined;
+    private timer: NodeJS.Timeout | undefined;
+    private readonly disposables: vscode.Disposable[] = [];
+
+    constructor(private readonly client: LspClient) {
+        this.disposables.push(
+            vscode.window.onDidChangeTextEditorSelection(
+                (e) => this.schedule(e.textEditor)),
+            vscode.window.onDidChangeActiveTextEditor(
+                (ed) => { if (ed) this.schedule(ed); }));
+    }
+
+    toggle(): void {
+        if (this.panel) {
+            this.panel.dispose();
+            return;
+        }
+        this.panel = vscode.window.createWebviewPanel(
+            'hol4.goalsPane',
+            'HOL Goals',
+            { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+            { retainContextWhenHidden: true });
+        this.panel.onDidDispose(() => {
+            if (this.timer) clearTimeout(this.timer);
+            this.timer = undefined;
+            this.panel = undefined;
+        });
+        this.renderIdle('Move the cursor into a Proof … QED body to see goals.');
+        if (vscode.window.activeTextEditor) {
+            this.schedule(vscode.window.activeTextEditor);
+        }
+    }
+
+    dispose(): void {
+        if (this.timer) clearTimeout(this.timer);
+        for (const d of this.disposables) d.dispose();
+        if (this.panel) this.panel.dispose();
+    }
+
+    private schedule(editor: vscode.TextEditor): void {
+        if (!this.panel) return;
+        if (editor.document.languageId !== KERNEL_ID) return;
+        if (this.timer) clearTimeout(this.timer);
+        this.timer = setTimeout(() => this.refresh(editor), DEBOUNCE_MS);
+    }
+
+    private async refresh(editor: vscode.TextEditor): Promise<void> {
+        if (!this.panel) return;
+        const doc = editor.document;
+        const pos = editor.selection.active;
+        // VS Code positions are UTF-16 code units; server expects
+        // UTF-8 byte offsets, so a line containing ∀ / ‘’ / ⇒ etc.
+        // otherwise lands the walker on the wrong step.
+        const params: GoalStateParams = {
+            textDocument: { uri: doc.uri.toString() },
+            position: {
+                line: pos.line,
+                character: utf16ToUtf8ByteOffset(doc, pos.line, pos.character),
+            },
+        };
+        let reply: GoalStateResponse | null | undefined;
+        try {
+            reply = await this.client.sendRequest<GoalStateResponse | null>(
+                '$/hol/goalState', params);
+        } catch (err) {
+            this.renderIdle(`goalState request failed: ${err}`);
+            return;
+        }
+        if (!this.panel) return;
+        this.render(reply);
+    }
+
+    private render(reply: GoalStateResponse | null | undefined): void {
+        if (!reply) {
+            this.renderIdle('No goal state at this position.');
+            return;
+        }
+        if (reply.status === 'pending') {
+            this.renderIdle('Compile in progress — goal state pending.');
+            return;
+        }
+        if (reply.error) {
+            this.renderStatus(reply, `<div class="err">${escapeHtml(reply.error)}</div>`);
+            return;
+        }
+        if (reply.pretty && reply.pretty.length > 0) {
+            this.renderStatus(reply,
+                `<pre class="pretty">${ansiToHtml(reply.pretty)}</pre>`);
+            return;
+        }
+        const goals = reply.goals ?? [];
+        if (goals.length === 0) {
+            this.renderStatus(reply, '<div class="ok">No open goals.</div>');
+            return;
+        }
+        const rows = goals.map((g, i) => {
+            // HOL convention: reverse the array so the oldest
+            // assumption sits at index [0] at the top.
+            const asms = (g.asms ?? []).slice().reverse().map((a, n) =>
+                `<div class="asm">[${n}]&nbsp;&nbsp;${escapeHtml(a)}</div>`).join('');
+            const hdr = goals.length > 1
+                ? `Goal ${i + 1} of ${goals.length}` : `Goal ${i + 1}`;
+            return `
+                <div class="goal">
+                  <div class="hdr">${hdr}</div>
+                  ${asms ? `<div class="asms">${asms}</div>` : ''}
+                  <div class="concl">${escapeHtml(g.goal)}</div>
+                </div>`;
+        }).join('');
+        this.renderStatus(reply, rows);
+    }
+
+    private renderStatus(reply: GoalStateResponse, body: string): void {
+        const stepInfo = reply.step != null
+            ? `<span class="step">step ${reply.step}</span>` : '';
+        const opaque = reply.opaque ? '<span class="opaque">(opaque)</span>' : '';
+        const thm = reply.theorem ? escapeHtml(reply.theorem) : '';
+        const header = thm
+            ? `<div class="thm">${thm} ${stepInfo} ${opaque}</div>` : '';
+        this.setHtml(`${header}${body}`);
+    }
+
+    private renderIdle(message: string): void {
+        this.setHtml(`<div class="idle">${escapeHtml(message)}</div>`);
+    }
+
+    private setHtml(body: string): void {
+        if (!this.panel) return;
+        this.panel.webview.html = wrap(body);
+    }
+}
+
+function utf16ToUtf8ByteOffset(
+    doc: vscode.TextDocument,
+    line: number,
+    character: number
+): number {
+    if (line < 0 || line >= doc.lineCount) return character;
+    const prefix = doc.lineAt(line).text.substring(0, character);
+    return Buffer.byteLength(prefix, 'utf8');
+}
+
+/** Translate the VT100 SGR escapes HOL's `PPBackEnd.vt100_terminal`
+ * emits into inline HTML spans.  Handles reset (0), bold (1), and
+ * 8-colour foreground (30-37 / 90-97). */
+function ansiToHtml(input: string): string {
+    const parts = input.split(/\x1B\[([0-9;]*)m/);
+    let openSpans = 0;
+    let out = '';
+    for (let i = 0; i < parts.length; i++) {
+        if (i % 2 === 0) {
+            out += escapeHtml(parts[i]);
+        } else {
+            const codes = parts[i].split(';').map(s => parseInt(s, 10) || 0);
+            for (const code of codes) {
+                if (code === 0) {
+                    while (openSpans > 0) { out += '</span>'; openSpans--; }
+                } else {
+                    const cls = sgrClass(code);
+                    if (cls !== undefined) {
+                        out += `<span class="${cls}">`;
+                        openSpans++;
+                    }
+                }
+            }
+        }
+    }
+    while (openSpans > 0) { out += '</span>'; openSpans--; }
+    return out;
+}
+
+function sgrClass(code: number): string | undefined {
+    if (code === 1) return 'ansi-bold';
+    if (code >= 30 && code <= 37) return `ansi-fg-${code - 30}`;
+    if (code >= 90 && code <= 97) return `ansi-fg-b${code - 90}`;
+    return undefined;
+}
+
+function wrap(body: string): string {
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><style>
+  body { font-family: var(--vscode-editor-font-family, monospace);
+         font-size: var(--vscode-editor-font-size, 13px);
+         color: var(--vscode-editor-foreground);
+         margin: 0.5em; }
+  .thm { font-weight: bold; margin-bottom: 0.5em;
+         color: var(--vscode-symbolIcon-classForeground); }
+  .step { font-weight: normal;
+          color: var(--vscode-descriptionForeground); }
+  .opaque { font-weight: normal;
+            color: var(--vscode-editorWarning-foreground); }
+  .goal { margin-bottom: 1em; }
+  .hdr { color: var(--vscode-descriptionForeground);
+         font-size: 0.9em; margin-bottom: 0.2em; }
+  .asms { padding-left: 0.5em; margin-bottom: 0.3em; }
+  .asm { white-space: pre-wrap; }
+  .concl { white-space: pre-wrap;
+           border-top: 2px solid var(--vscode-editor-foreground);
+           padding-top: 0.4em; margin-top: 0.4em; }
+  .err { color: var(--vscode-editorError-foreground);
+         white-space: pre-wrap; }
+  .ok, .idle { color: var(--vscode-descriptionForeground); }
+  pre.pretty { margin: 0; white-space: pre-wrap;
+               font-family: inherit; font-size: inherit; }
+  .ansi-bold { font-weight: bold; }
+  .ansi-fg-0  { color: #808080; }
+  .ansi-fg-1  { color: var(--vscode-terminal-ansiRed, #cd3131); }
+  .ansi-fg-2  { color: var(--vscode-terminal-ansiGreen, #0dbc79); }
+  .ansi-fg-3  { color: var(--vscode-terminal-ansiYellow, #e5e510); }
+  .ansi-fg-4  { color: var(--vscode-terminal-ansiBlue, #2472c8); }
+  .ansi-fg-5  { color: var(--vscode-terminal-ansiMagenta, #bc3fbc); }
+  .ansi-fg-6  { color: var(--vscode-terminal-ansiCyan, #11a8cd); }
+  .ansi-fg-7  { color: var(--vscode-terminal-ansiWhite, #e5e5e5); }
+  .ansi-fg-b0 { color: var(--vscode-terminal-ansiBrightBlack, #666666); }
+  .ansi-fg-b1 { color: var(--vscode-terminal-ansiBrightRed, #f14c4c); }
+  .ansi-fg-b2 { color: var(--vscode-terminal-ansiBrightGreen, #23d18b); }
+  .ansi-fg-b3 { color: var(--vscode-terminal-ansiBrightYellow, #f5f543); }
+  .ansi-fg-b4 { color: var(--vscode-terminal-ansiBrightBlue, #3b8eea); }
+  .ansi-fg-b5 { color: var(--vscode-terminal-ansiBrightMagenta, #d670d6); }
+  .ansi-fg-b6 { color: var(--vscode-terminal-ansiBrightCyan, #29b8db); }
+  .ansi-fg-b7 { color: var(--vscode-terminal-ansiBrightWhite, #ffffff); }
+</style></head><body>${body}</body></html>`;
+}

--- a/src/lspClient.ts
+++ b/src/lspClient.ts
@@ -1,0 +1,181 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    State,
+} from 'vscode-languageclient/node';
+import { KERNEL_ID, error } from './common';
+
+/**
+ * Shape of the tiny slice of `LanguageClient` we monkey-patch.
+ * Kept narrow so future dep upgrades that break these hooks surface
+ * as compile errors rather than silent behaviour changes.
+ */
+interface PatchableConnection {
+    initialize(params: unknown): Promise<{
+        capabilities?: { positionEncoding?: unknown }
+    }>;
+}
+interface PatchableClient {
+    createConnection?: (...args: unknown[]) => Promise<PatchableConnection>;
+}
+
+/** Strip server-advertised `positionEncoding` so v9 client accepts
+ * a utf-8-declaring server.  Client falls back to its utf-16
+ * default; positions on non-ASCII lines are then translated on
+ * demand by callers (see goalsView.utf16ToUtf8ByteOffset). */
+function patchConnectionForPositionEncoding(client: LanguageClient): void {
+    const patch = client as unknown as PatchableClient;
+    const origCreateConnection = patch.createConnection?.bind(patch);
+    if (typeof origCreateConnection !== 'function') return;
+    patch.createConnection = async (...args: unknown[]) => {
+        const conn = await origCreateConnection(...args);
+        const origInitialize = conn.initialize.bind(conn);
+        conn.initialize = async (params: unknown) => {
+            const result = await origInitialize(params);
+            if (result?.capabilities?.positionEncoding !== undefined) {
+                delete result.capabilities.positionEncoding;
+            }
+            return result;
+        };
+        return conn;
+    };
+}
+
+/** Position argument for the `$/hol/goalState` custom request. */
+export interface GoalStatePosition {
+    line: number;
+    character: number;
+}
+
+export interface GoalStateParams {
+    textDocument: { uri: string };
+    position: GoalStatePosition;
+}
+
+export interface Goal {
+    asms: string[];
+    goal: string;
+}
+
+export interface GoalStateResponse {
+    theorem?: string;
+    step?: number;
+    goals?: Goal[];
+    /** Server-side pretty-printed rendering with VT100 ANSI colour
+     * escapes.  Present since the goalState LSP extension shipped;
+     * preferred over `goals` when non-empty. */
+    pretty?: string;
+    status?: string;
+    opaque?: boolean;
+    error?: string;
+}
+
+function resolveHolExecutable(fallbackHoldir: string): string | undefined {
+    const cfg = vscode.workspace.getConfiguration('hol4-mode');
+    const override = cfg.get<string>('lsp.executable');
+    if (override && override.trim() !== '') return override;
+    if (fallbackHoldir) return path.join(fallbackHoldir, 'bin', 'hol');
+    return undefined;
+}
+
+export class LspClient implements vscode.Disposable {
+    private client: LanguageClient | undefined;
+    private readonly output: vscode.OutputChannel;
+    private readonly status: vscode.StatusBarItem;
+    private readonly disposables: vscode.Disposable[] = [];
+
+    constructor(private readonly holdir: string) {
+        this.output = vscode.window.createOutputChannel('HOL4 LSP');
+        this.status = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Left, 100);
+        this.status.command = 'hol4-mode.lsp.showOutput';
+    }
+
+    async start(): Promise<void> {
+        const exe = resolveHolExecutable(this.holdir);
+        if (!exe) {
+            error('LSP: no `bin/hol` path resolved from ' +
+                'hol4-mode.lsp.executable, hol4-mode.holdir, or $HOLDIR');
+            this.showStatus('HOL LSP: no executable', true);
+            return;
+        }
+        if (!fs.existsSync(exe)) {
+            error(`LSP: ${exe} does not exist`);
+            this.showStatus('HOL LSP: exe missing', true);
+            return;
+        }
+
+        // No `transport:` field: the client defaults to stdio without
+        // appending the `--stdio` flag that `bin/hol lsp` rejects.
+        const serverOptions: ServerOptions = { command: exe, args: ['lsp'] };
+        const clientOptions: LanguageClientOptions = {
+            // vscode-languageclient's DocumentSelector type is
+            // distinct from the vscode API's, so we inline the
+            // literal rather than reusing `hol4selector`.
+            documentSelector: [
+                { scheme: 'file', language: KERNEL_ID },
+                { scheme: 'untitled', language: KERNEL_ID },
+            ],
+            synchronize: {
+                fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{sml,sig}'),
+            },
+            outputChannel: this.output,
+        };
+
+        this.client = new LanguageClient(
+            'hol4-lsp', 'HOL4 LSP', serverOptions, clientOptions);
+        patchConnectionForPositionEncoding(this.client);
+        this.disposables.push(this.client.onDidChangeState(e => {
+            if (e.newState === State.Running) {
+                this.showStatus('HOL LSP', false);
+            } else if (e.newState === State.Stopped) {
+                this.showStatus('HOL LSP: stopped', true);
+            } else {
+                this.showStatus('HOL LSP: starting…', false);
+            }
+        }));
+
+        try {
+            await this.client.start();
+        } catch (err) {
+            error(`LSP failed to start: ${err}`);
+            this.showStatus('HOL LSP: failed', true);
+        }
+    }
+
+    async restart(): Promise<void> {
+        if (this.client) {
+            await this.client.stop();
+            await this.client.start();
+        } else {
+            await this.start();
+        }
+    }
+
+    showOutput(): void {
+        this.output.show(true);
+    }
+
+    async sendRequest<T>(method: string, params: unknown): Promise<T | undefined> {
+        if (!this.client || this.client.state !== State.Running) return undefined;
+        return this.client.sendRequest<T>(method, params);
+    }
+
+    dispose(): void {
+        for (const d of this.disposables) d.dispose();
+        this.status.dispose();
+        if (this.client) {
+            this.client.stop().catch(() => { /* best-effort */ });
+        }
+    }
+
+    private showStatus(text: string, warn: boolean): void {
+        this.status.text = warn ? `$(warning) ${text}` : `$(check) ${text}`;
+        this.status.tooltip = 'Click to open the HOL4 LSP output channel';
+        this.status.show();
+    }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -393,7 +393,7 @@ function parsePretty(value: PrettyString): Pretty {
     }
 }
 
-const escapeHtml = (s: string): string =>
+export const escapeHtml = (s: string): string =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
         .replace(/'/g, '&#39;').replace(/"/g, '&quot;');
 


### PR DESCRIPTION
This requires matching work that is on HOL branch `LSP-implementation`, but which will soon be on `develop` (and then `master`).  I've tested a little on my local Mac version of VS Code. All coding done by Claude.  I'm not super happy about the need to hack around the `utf8` *vs* `utf16` encoding thing. There is still much to be done on both client and server sides. 

------

This provides an optional (but enabled by default via `hol4-mode.lsp.enabled`) LSP client that spawns `bin/hol lsp` and drives:

- inline diagnostics + hover via `vscode-languageclient/node`;
- a side-pane HOL Goals webview that follows the cursor *via* the server's `$/hol/goalState' extension.  Server-rendered “pretty” output (`goalFrag.pp_goalstate` with VT100 colour) is used to make the goal-states attractive.
- palette commands to toggle the pane, restart the server, and reveal the output channel.  Default keybinding `Ctrl/Cmd+H Ctrl/Cmd+G` for the pane toggle.

Coexists with the existing HOLIDE hover / definition providers; they stack in the tooltip.  `hol4-mode.lsp.enabled=false` disables the client entirely.  Resolves `bin/hol` from
`hol4-mode.lsp.executable` -> `hol4-mode.holdir/bin/hol` -> `$HOLDIR/bin/hol`.

Two workarounds embedded for `vscode-languageclient` v9:
- omit `transport: TransportKind.stdio` so the client doesn't append `--stdio', which our server rejects;
- monkey-patch `createConnection` to strip the server's `positionEncoding: utf-8` from the initialize response, since v9 hardcodes utf-16 acceptance.  The goals pane compensates by translating VS Code's UTF-16 code-unit positions to UTF-8 byte offsets before sending `$/hol/goalState`.  Diagnostic / hover ranges from the built-in providers stay unadjusted; on non-ASCII lines they shift by a few characters.